### PR TITLE
Add ability to write directly to PDF files.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ chrono = "0.4.19"
 qrcode = "0.12.0"
 regex = "1.5.4"
 svg = "0.17.0"
+svg2pdf = "0.11.0"
 
 [dev-dependencies]
 anyhow = "1.0.44"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -24,6 +24,7 @@ fn main() -> anyhow::Result<()> {
     })?;
 
     qrbill.write_to_file("test.svg", false)?;
+    qrbill.write_to_pdf_file("test.pdf", false)?;
 
     Ok(())
 }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -23,8 +23,8 @@ fn main() -> anyhow::Result<()> {
         payment_line: true,
     })?;
 
-    qrbill.write_to_file("test.svg", false)?;
-    qrbill.write_to_pdf_file("test.pdf", false)?;
+    qrbill.write_svg_to_file("test.svg", false)?;
+    qrbill.write_pdf_to_file("test.pdf", false)?;
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -654,7 +654,7 @@ impl QRBill {
     /// Writes the represented QR-Bill into an SVG file.
     ///
     /// * `full_page`: Makes the generated SVG the size of a full A4 page.
-    pub fn write_to_file(
+    pub fn write_svg_to_file(
         &self,
         path: impl AsRef<std::path::Path>,
         full_page: bool,
@@ -669,7 +669,7 @@ impl QRBill {
     /// Writes the represented QR-Bill into a PDF file.
     ///
     /// * `full_page`: Makes the generated SVG the size of a full A4 page.
-    pub fn write_to_pdf_file(
+    pub fn write_pdf_to_file(
         &self,
         path: impl AsRef<std::path::Path>,
         full_page: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,6 +168,8 @@ pub enum Error {
     Qr(#[from] QrError),
     #[error("An IO error occured.")]
     Io(#[from] std::io::Error),
+    #[error("An error occurred when generating PDF")]
+    Pdf(#[from] svg2pdf::usvg::Error),
 }
 
 pub enum Address {
@@ -661,6 +663,24 @@ impl QRBill {
 
         std::fs::write(path, svg)?;
 
+        Ok(())
+    }
+
+    /// Writes the represented QR-Bill into a PDF file.
+    ///
+    /// * `full_page`: Makes the generated SVG the size of a full A4 page.
+    pub fn write_to_pdf_file(
+        &self,
+        path: impl AsRef<std::path::Path>,
+        full_page: bool,
+    ) -> Result<(), Error> {
+        let svg = self.create_svg(full_page)?;
+        let mut options = svg2pdf::usvg::Options::default();
+        options.fontdb_mut().load_system_fonts();
+        let tree = svg2pdf::usvg::Tree::from_str(&svg, &options)?;
+
+        let pdf = svg2pdf::to_pdf(&tree, svg2pdf::ConversionOptions::default(), svg2pdf::PageOptions::default());
+        std::fs::write(path, pdf)?;
         Ok(())
     }
 


### PR DESCRIPTION
This uses the [`svg2pdf`](https://github.com/typst/svg2pdf) crate to do the hard work. Perhaps it should go behind a feature gate?

The second commit makes the writer functions names more symmetric, but it's not necessary, particularly if you prefer to have SVG as the primary or default format.
