### PR TITLE
Fix issue 4 by parsing into u128

### DIFF
--- a/src/iso11649.rs
+++ b/src/iso11649.rs
@@ -29,7 +29,7 @@ impl Iso11649 {
                 i64::from_str_radix(&v.to_string(), 36).expect("This is a bug. Please rport it.")
             })
             .fold(String::new(), |a, b| format!("{}{}", a, b))
-            .parse::<u64>()
+            .parse::<u128>()
             .expect("This is a bug. Please report it.")
             % 97
             == 1;


### PR DESCRIPTION
Trivial fix for #4: parse into `u128` instead of `u64`.

However, the earlier commits introduce stuff which is not strictly necessary, including

+ Add dev-dependency on [`rstest`](https://docs.rs/rstest/latest/rstest/)
+ Add a bunch of tests
+ Change `try_new` parameter from `String` to `&str`
+ Rename `Error::InvalidFormat` to `Error::MissingLeadingRF`
+ In `Error::InvalidCharacter`, report all invalid characters present

Alternatively, I could donate my implementation of ISO 11649, as discussed in #4.