### PR TITLE
Remove extended label when debtor present

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -800,17 +800,16 @@ impl QRBill {
 
         y_pos += mm(1.0);
 
-        group = group.add(
-            Text::new("")
-                .add(svg::node::Text::new(self.label(&LABEL_PAYABLE_BY_EXTENDED)))
-                .set("x", margin)
-                .set("y", y_pos)
-                .style(Self::HEAD_FONT),
-        );
-        y_pos += line_space;
-
+        // Add debtor info.
         if let Some(debtor) = &self.debtor {
-            for line in debtor.as_paragraph(MAX_CHARS_RECEIPT_LINE) {
+            group = Self::add_header(
+                group,
+                self.label(&LABEL_PAYABLE_BY),
+                margin,
+                &mut y_pos,
+                line_space,
+            );
+            for line in debtor.as_paragraph(MAX_CHARS_PAYMENT_LINE) {
                 group = group.add(
                     Text::new("")
                         .add(svg::node::Text::new(line))
@@ -821,7 +820,15 @@ impl QRBill {
                 y_pos += line_space;
             }
         } else {
-            group = Self::draw_blank_rectangle(group, margin, y_pos, mm(52.0), mm(25.0));
+            group = Self::add_header(
+                group,
+                self.label(&LABEL_PAYABLE_BY_EXTENDED),
+                margin,
+                &mut y_pos,
+                line_space,
+            );
+            group =
+                Self::draw_blank_rectangle(group, margin, y_pos, mm(52.0), mm(20.0));
         }
 
         group = group.add(


### PR DESCRIPTION
Before:
![buggy](https://github.com/Yatekii/qrbill/assets/2570854/218a93d9-2c70-4a6c-8ff0-1ba783ecd7d8)
After:
![fixed](https://github.com/Yatekii/qrbill/assets/2570854/6f7e121e-d2a3-4b85-8db5-6a5c10280246)
However, when no debtor is provided, the detail still appears:
![nopayee](https://github.com/Yatekii/qrbill/assets/2570854/25926df1-57c6-4dfe-bd58-17e961b53bd3)
