### PR TITLE
Fix position of amount rectangle

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -863,7 +863,7 @@ impl QRBill {
             );
         } else {
             group =
-                Self::draw_blank_rectangle(group, margin + mm(25.0), mm(75.0), mm(27.0), mm(11.0));
+                Self::draw_blank_rectangle(group, margin + mm(25.0), mm(70.6), mm(27.0), mm(11.0));
         }
 
         group = group.add(


### PR DESCRIPTION
Before:
![buggy](https://github.com/Yatekii/qrbill/assets/2570854/7c38d8b5-932b-4124-aae3-a3ab0df8453f)
After:
![fixed](https://github.com/Yatekii/qrbill/assets/2570854/ecb37354-d2a5-4dc4-87b0-1dc557f14075)

Now that I look at it, the top-left corner marker looks smaller than the others. Is that intentional? Can't find anything after a quick look in the spec.