### PR TITLE
Add tests for data encoded in QR

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,5 +27,9 @@ deunicode = "1.6.0"
 
 [dev-dependencies]
 anyhow = "1.0.44"
+bardecoder = "0.5.0"
+image = "0.24.0"
 pretty_assertions = "1.4.0"
+resvg = "0.42.0"
 rstest = "0.21.0"
+temp_testdir = "0.2.3"

--- a/src/iso11649.rs
+++ b/src/iso11649.rs
@@ -225,7 +225,7 @@ mod tests {
 
         let reference_input = "ABCD 1234 AU";
         let reference = Iso11649::new(reference_input);
-        let reference_coded = chunked(&reference.with_checksum());
+        let reference_coded = reference.with_checksum();
 
         let bill = QRBill::new(QRBillOptions {
             account: iban.parse().expect("Hard-wired test IBAN should parse"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -389,7 +389,7 @@ impl Reference {
     fn data_list(&self) -> Vec<String> {
         match self {
             Reference::Qrr(esr) => vec!["QRR".to_string(), esr.to_raw()],
-            Reference::Scor(scor) => vec!["SCOR".to_string(), chunked(&scor.with_checksum())],
+            Reference::Scor(scor) => vec!["SCOR".to_string(), scor.with_checksum()],
             Reference::None => vec!["NON".to_string(), "".to_string()],
         }
     }


### PR DESCRIPTION
Add 3 tests verifying that the data encoded in a QR code are recovered correctly:

1.  `qr_data` verifies that `QRBill::qr_data()` returns the correct information.
2. `todo_qr_data_via_in_memory_image`  *NOT WORKING: DISABLED* to be fixed later. Intended to be the same as no. 3, but in-memory rather than via file I/O.
3. `qr_data_via_saved_image`
   - generates SVG
   - converts it to PNG
   - writes it to temporary file
   - decodes the data stored in QR code in the file
   - verifies that the recovered data match the inputs

Notes:

+ The tests are *slightly* flaky: I have come across some, quite rare, input data which result in scanning of the QR code failing to find the alignment markers. I plan to add some property-based tests (once the in-memory test works; it would be veeeery slow via file I/O) which could give us more insight into this.

+ The bill due date appears to have no effect on the contents of the QR code. I guess that's a bug.

+ There are 7 blank lines in the QR-encoded data, between the creditor and the amount. Are these spurious? Is this where we're failing to write some information such as the aforementioned due date?

+ These tests merely check that we can recover the data we send in, from the QR codes we generate. But they do not verify that the format of the generated data matches the requirements of the QRbill standard. Is there some automated process for verifying the latter?

+ Adds a number of dev-dependencies.
